### PR TITLE
Add space so that inputs don't overlap

### DIFF
--- a/beta.html
+++ b/beta.html
@@ -64,7 +64,7 @@
             display: inline;
 
             float: left;
-            width: 16em;
+            width: 18em;
             height: 1.6em;
             text-decoration: none;
             padding: 0.2em 0.6em;


### PR DESCRIPTION
Add Space to list box descriptions so that the input boxes don't overlap each other.

The screenshots below are on Chrome 85.0.4183.83, on windows 10.

### Before, mobile
![Before - Mobile](https://user-images.githubusercontent.com/386023/92334402-109e8f00-f053-11ea-9134-2bac9b796fae.png)
### After, mobile
![After - Mobile](https://user-images.githubusercontent.com/386023/92334405-172d0680-f053-11ea-9093-ba87f14ab8a6.png)
### Before, computer
![Before - Computer](https://user-images.githubusercontent.com/386023/92334408-1dbb7e00-f053-11ea-88a0-294a7c328e68.png)
### After, computer
![After - Computer](https://user-images.githubusercontent.com/386023/92334413-21e79b80-f053-11ea-9634-ba910094e3c8.png)

